### PR TITLE
Do not clear the chassis in etcd side while shutting down tuplenet #3

### DIFF
--- a/src/control/logicaldev/switch.go
+++ b/src/control/logicaldev/switch.go
@@ -10,6 +10,7 @@ type SwitchPort struct {
 	IP                 string `tn:"ip" json:"ip"`
 	MAC                string `tn:"mac" json:"mac"`
 	PeerRouterPortName string `tn:"peer,omitempty" json:"peer,omitempty"`
+	Chassis            string `tn:"chassis,omitempty" json:"chassis,omitempty"`
 
 	Owner *Switch
 }

--- a/src/tests/test_simple_hv.sh
+++ b/src/tests/test_simple_hv.sh
@@ -59,8 +59,9 @@ pmsg "ofport of tupleNet-3232261130 in hv2 is $ofport_hv_agent"
 # and reboot hv2
 pmsg "terminate hv2"
 kill_tuplenet_daemon hv2 -TERM
+tpctl ch del hv2 || exit_test
 wait_for_flows_unchange
-# tupleNet-3232261122 should not exist in hv1, because hv2 exit gracefull
+# tupleNet-3232261122 should not exist in hv1
 ! is_port_exist hv1 tupleNet-3232261122 || exit_test
 pmsg "restart hv2"
 tuplenet_boot hv2 192.168.100.2
@@ -96,6 +97,7 @@ verify_pkt $expect_pkt $real_pkt || exit_test
 
 # kill hv2, create a new hv3 but get same IP
 kill_tuplenet_daemon hv2 -TERM
+tpctl ch del hv2 || exit_test
 sim_destroy hv2
 remove_sim_id_from_array hv2 # remove the hv2 from sim_array
 sleep 1
@@ -190,7 +192,7 @@ wait_for_flows_unchange
 is_port_exist hv1 tupleNet-3232261124 || exit_test
 
 # delete hv4, add hv6 at same time
-etcd_chassis_del hv4
+tpctl ch del hv4 || exit_test
 etcd_chassis_add hv6 192.168.100.6 10
 etcd_lr_add LR-dummy1 hv6 # hv6 is a chassis in virtual network map, it will
                          # be touched automaticlly

--- a/src/tests/test_simple_tpctl.sh
+++ b/src/tests/test_simple_tpctl.sh
@@ -187,9 +187,10 @@ for i in `seq 1 4`; do
   result="$(tpctl lsp show LS-${i})"
   expected="
 LS-${i}_to_LR-${i}:
-  - ip  : 10.0.0.${i}
-  - mac : f2:01:0a:00:00:0${i}
-  - peer: LR-${i}_to_LS-${i}
+  - ip     : 10.0.0.${i}
+  - mac    : f2:01:0a:00:00:0${i}
+  - peer   : LR-${i}_to_LS-${i}
+  - chassis: 
 "
 
   equal_str "$result" "$expected" || exit_test

--- a/src/tuplenet/lcp/commit_ovs.py
+++ b/src/tuplenet/lcp/commit_ovs.py
@@ -112,7 +112,7 @@ def update_ovsport(record, entity_zoo):
         return
 
     if action_type in ['old', 'delete']:
-        logger.info("try to move port to sink %s uuid:%s", name, uuid)
+        logger.info("try to move port %s to sink uuid:%s", name, uuid)
         entity_zoo.move_entity2sink(entity_type, name)
     else:
         logger.info("try to add ovsport entity %s ofport:%d, uuid:%s in zoo",

--- a/src/tuplenet/lcp/tuplerun.py
+++ b/src/tuplenet/lcp/tuplerun.py
@@ -51,10 +51,7 @@ def clean_env(extra, ret):
         os.remove(extra['flock'])
     if extra.has_key('lm'):
         extra['lm'].stop_all_watches()
-    if extra.has_key('system_id'):
-        logger.info("clean etcd side system_id record")
-        delete_self_chassis(extra['system_id'])
-    pipe.destory_runtime_folder()
+    pipe.destory_runtime_files()
 
 def get_if_ip(ifname_list = ['eth0', 'br0']):
     for ifname in ifname_list:
@@ -116,11 +113,6 @@ def init_env(options):
     create_watch_master(options.host, options.path_prefix, system_id)
     cm.build_br_integration()
     cm.set_tunnel_tlv()
-
-def delete_self_chassis(system_id):
-    wmaster = extra['lm']
-    key = 'chassis/{}'.format(system_id)
-    wmaster.delete_entity_no_retry(key)
 
 def update_chassis(interface_list):
     if re.match(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", interface_list[0]):

--- a/src/tuplenet/pkt_controller/pkt_controller.c
+++ b/src/tuplenet/pkt_controller/pkt_controller.c
@@ -307,7 +307,7 @@ process_unknow_dst_pkt(struct ofputil_packet_in *pin, struct ofpbuf *userdata)
                                                     sizeof(struct eth_header));
         if (tmhashmap_add_node(ntohl(ip_hdr->ip_dst)) != TP_STATUS_OK) {
             VLOG_INFO_RL(&rl, "we may receive same ip packet before in 100ms, "
-                      "ignore this packet");
+                        "ignore this packet");
             return TP_STATUS_OK;
         }
 
@@ -318,8 +318,8 @@ process_unknow_dst_pkt(struct ofputil_packet_in *pin, struct ofpbuf *userdata)
             return status;
         }
     } else {
-        VLOG_WARN("invalid type in eth header:0x%x, maybe a vlan packet",
-                  eth_hdr->type);
+        VLOG_INFO_RL(&rl, "receive a packet with invalid type in eth "
+                     "header:0x%x", eth_hdr->type);
         //would not process vlan packet
         return TP_STATUS_ERR_PKT;
     }

--- a/src/tuplenet/tp_utils/pipe.py
+++ b/src/tuplenet/tp_utils/pipe.py
@@ -49,13 +49,11 @@ def create_runtime_folder():
     except Exception as err:
         logger.error("failed to create tuplenet runtime files, err:%s", err)
 
-def destory_runtime_folder():
+def destory_runtime_files():
     try:
         if os.path.exists(PKT_CONTROLLER_PIPE_PATH):
             os.remove(PKT_CONTROLLER_PIPE_PATH)
         if os.path.exists(DEBUG_PIPE_PATH):
             os.remove(DEBUG_PIPE_PATH)
-        if os.path.exists(RUNNING_ENV_PATH):
-            os.rmdir(RUNNING_ENV_PATH)
     except Exception as err:
         logger.warning("failed to clear tuplenet runtime files, err:%s", err)

--- a/src/tuplenet/version.py
+++ b/src/tuplenet/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.10'
+__version__ = '0.1.11'
 git_version = ''


### PR DESCRIPTION
1. update tuplerun.py to avoid delete chassis in cleaning env
2. update test_simple_hv.sh to use tpctl to delete chassis in etcd side
3. do not delete whole folder of runtime-folder
4. update logicaldev/switch.go to show chassis while print details of lsp
5. bump version to 0.1.11