### PR TITLE
Deleting a edge chassis in etcd means we should stop this chassis latter

### DIFF
--- a/src/tests/test_simple_bfd.sh
+++ b/src/tests/test_simple_bfd.sh
@@ -21,14 +21,14 @@ etcd_lr_add edge2 hv3
 etcd_ls_add outside1
 etcd_ls_add outside2
 
-start_tuplenet_daemon hv1 192.168.100.1
-ONDEMAND=0 GATEWAY=1 start_tuplenet_daemon hv2 192.168.100.2
-ONDEMAND=0 GATEWAY=1 start_tuplenet_daemon hv3 192.168.100.3
+start_tuplenet_daemon hv1 172.20.11.2
+ONDEMAND=0 GATEWAY=1 start_tuplenet_daemon hv2 172.20.11.3
+ONDEMAND=0 GATEWAY=1 start_tuplenet_daemon hv3 172.20.11.4
 install_arp
 wait_for_brint # waiting for building br-int bridge
 
 port_add hv1 lsp-portA || exit_test
-port_add hv2 lsp-portB || exit_test
+port_add hv1 lsp-portB || exit_test
 port_add hv3 lsp-portC || exit_test
 
 # link LS-A to LR-A
@@ -105,6 +105,40 @@ wait_for_packet # wait for packet
 real_pkt=`get_tx_pkt hv1 lsp-portA`  # the received packets has no change, becuase we don't want to get a feed back
 verify_pkt "$expect_pkt" "$real_pkt" || exit_test
 
+# set static route on edge1
+etcd_lsr_add edge1 0.0.0.0 0 172.20.11.1 edge1_to_outside1
+# set static route on edge2
+etcd_lsr_add edge2 0.0.0.0 0 172.20.11.1 edge2_to_outside2
+patchport_add hv2 patchport-outside1 || exit_test
+patchport_add hv3 patchport-outside2 || exit_test
+
+# add patchport into etcd
+etcd_patchport_add outside1 patchport-outside1
+etcd_patchport_add outside2 patchport-outside2
+wait_for_flows_unchange
+
+ip_src=`ip_to_hex 10 10 2 3`
+ip_dst=`ip_to_hex 172 20 11 12`
+ttl=09
+packet=`build_icmp_request 000006080702 000006080602 $ip_src $ip_dst $ttl f891 8510`
+inject_pkt hv1 lsp-portB "$packet" || exit_test
+wait_for_packet # wait for packet
+ttl=fd
+expect_pkt=""
+# should not receive any icmp packet, this packet should be forward to hv2(which
+# has no 172 20 11 12, but it will ask arp)
+real_pkt=`get_tx_pkt hv1 lsp-portB`
+verify_pkt "$expect_pkt" "$real_pkt" || exit_test
+sleep 1
+# send icmp packet again. hv2 will send it to outside phy which deliver to hv3,
+# once hv3 get the icmp(from outside network) then generate icmp route back to
+# hv1's lsp-portB
+inject_pkt hv1 lsp-portB "$packet" || exit_test
+wait_for_packet # wait for packet
+expect_pkt=`build_icmp_response 000006080602 000006080702 $ip_dst $ip_src $ttl 0491 8d10`
+real_pkt=`get_tx_pkt hv1 lsp-portB`
+verify_pkt "$expect_pkt" "$real_pkt" || exit_test
+
 # kill a edge tuplenet
 kill_tuplenet_daemon hv2 -TERM
 # restart it again to simulate a upgrade
@@ -140,5 +174,36 @@ wait_for_flows_unchange
 is_tunnel_bfd_disable hv1 hv2 || exit_test
 is_tunnel_bfd_disable hv1 hv3 || exit_test
 
+# bring lsr back
+etcd_lsr_add LR-A 0.0.0.0 0 100.10.10.2 "LR-A_to_m1"
+etcd_lsr_add LR-A 0.0.0.0 0 100.10.10.2 "LR-A_to_m2"
+wait_for_flows_unchange
+is_tunnel_bfd_enable hv1 hv2 || exit_test
+is_tunnel_bfd_enable hv1 hv3 || exit_test
+is_tunnel_bfd_enable hv2 hv1 || exit_test
+is_tunnel_bfd_enable hv2 hv3 || exit_test
+is_tunnel_bfd_enable hv3 hv1 || exit_test
+is_tunnel_bfd_enable hv3 hv2 || exit_test
 
+
+is_port_exist hv1 tupleNet-3232261123 || exit_test
+is_port_exist hv2 tupleNet-3232261123 || exit_test
+# delete hv3 record in etcd side. hv3's all tunnel ports should disable bfd
+# other host should not has tunnelport which dst-ip is hv3
+tpctl ch del hv3 || exit_test
+wait_for_flows_unchange
+is_tunnel_bfd_disable hv3 hv1 || exit_test
+is_tunnel_bfd_disable hv3 hv2 || exit_test
+! is_port_exist hv1 tupleNet-3232261123 || exit_test
+! is_port_exist hv2 tupleNet-3232261123 || exit_test
+
+kill_tuplenet_daemon hv3 -TERM
+ONDEMAND=0 GATEWAY=1 tuplenet_boot hv3 192.168.100.3
+wait_for_flows_unchange
+is_tunnel_bfd_enable hv3 hv1 || exit_test
+is_tunnel_bfd_enable hv3 hv2 || exit_test
+is_tunnel_bfd_enable hv1 hv3 || exit_test
+is_tunnel_bfd_enable hv2 hv3 || exit_test
+
+wait_for_flows_unchange
 pass_test

--- a/src/tests/test_simple_ecmp3.sh
+++ b/src/tests/test_simple_ecmp3.sh
@@ -6,12 +6,14 @@ sim_create hv1 || exit_test
 sim_create hv2 || exit_test
 sim_create hv3 || exit_test
 sim_create hv4 || exit_test
+sim_create hv5 || exit_test
 sim_create ext1 || exit_test
 net_create phy || exit_test
 net_join phy hv1 || exit_test
 net_join phy hv2 || exit_test
 net_join phy hv3 || exit_test
 net_join phy hv4 || exit_test
+net_join phy hv5 || exit_test
 net_join phy ext1 || exit_test
 
 # create logical switch and logical router first
@@ -24,6 +26,7 @@ GATEWAY=1 ONDEMAND=0 start_tuplenet_daemon hv2 192.168.100.3
 GATEWAY=1 ONDEMAND=0 start_tuplenet_daemon hv3 192.168.100.4
 GATEWAY=1 ONDEMAND=0 start_tuplenet_daemon hv4 192.168.100.5
 start_tuplenet_daemon ext1 192.168.100.6
+HASH_FN=nw_src start_tuplenet_daemon hv5 192.168.100.7
 install_arp
 wait_for_brint # waiting for building br-int bridge
 
@@ -232,7 +235,7 @@ verify_pkt "$expect_pkt" "$real_pkt" || exit_test
 
 # only get a central_lr, 2 LS, test if script can add ecmp road
 ! add_ecmp_road hv4 192.168.100.57/24 || exit_test
-# adding a new ecmp road(on hv3)
+# adding a new ecmp road(on hv4)
 init_ecmp_road hv4 192.168.100.57/24 10.10.0.0/16 192.168.100.1 || exit_test
 wait_for_flows_unchange # waiting for install flows
 
@@ -280,8 +283,84 @@ verify_pkt $expect_pkt $real_pkt || exit_test
 add_ecmp_road hv3 192.168.100.61/24 || exit_test
 port_add hv1 lsp-portC || exit_test
 etcd_lsp_add LS-B lsp-portC 10.10.2.3 00:00:06:08:09:05
+port_add hv5 lsp-portD || exit_test
+etcd_lsp_add LS-B lsp-portD 10.10.2.4 00:00:06:08:09:06
 wait_for_flows_unchange # waiting for install flows
-# try to send icmp to edge1(hv2) from hv1, but edge2(hv3) cannot receive it due
+
+# NOTE: kill hv5 here because we want hv5 send packet to hv3(edge),
+# so stopping tuplenet on hv5 would not update ovsflow even we
+# delete hv3 from etcd side.
+# Besides that, should disable bfd on hv5, make it believe that hv3
+# is still alive
+kill_tuplenet_daemon hv5 -TERM
+sleep 2
+disable_bfd hv5 hv3
+
+# del hv3(edge node), the hv3 tuplenet will disable icmp ping of LR-edge, but
+# other features should works well. hv3 can help to forward packet as usual.
+tpctl ch del hv3 || exit_test
+wait_for_flows_unchange
+
+# send arp to hv edge from ext1
+# send arp packet to request feedback
+src_mac=`get_ovs_iface_mac ext1 br0`
+src_mac=${src_mac//:} # convert xx:xx:xx:xx:xx:xx -> xxxxxxxxxxxx
+sha=$src_mac
+spa=`ip_to_hex 192 168 100 6`
+tpa=`ip_to_hex 192 168 100 61`
+# build arp request
+packet=ffffffffffff${sha}08060001080006040001${sha}${spa}ffffffffffff${tpa}
+inject_pkt ext1 br0 "$packet" || exit_test
+wait_for_packet # wait for packet
+reply_ha=f201c0a8643d
+expect_pkt=${sha}${reply_ha}08060001080006040002${reply_ha}${tpa}${sha}${spa}
+real_pkt=`get_tx_last_pkt ext1 br0`
+verify_pkt "$expect_pkt" "$real_pkt" || exit_test
+
+# send icmp from ext1 to lsp-portA through hv3. even hv3 was deleted, but
+# hv3 still forward packet
+ip_src=`ip_to_hex 192 168 100 6`
+ip_dst=`ip_to_hex 10 10 1 2`
+ttl=06
+packet=`build_icmp_request $src_mac $reply_ha $ip_src $ip_dst $ttl af85 8510`
+inject_pkt ext1 br0 "$packet" || exit_test
+wait_for_packet # wait for packet
+ttl=04
+expect_pkt=`build_icmp_request 000006080601 000006080701 $ip_src $ip_dst $ttl b185 8510`
+real_pkt=`get_tx_last_pkt hv1 lsp-portA`
+verify_pkt $expect_pkt $real_pkt || exit_test
+
+# on the other hand, hv3's edge should not response icmp anymore.
+ip_src=`ip_to_hex 192 168 100 6`
+ip_dst=`ip_to_hex 192 168 100 61`
+expect_pkt="`get_tx_pkt ext1 br0`"
+ttl=06
+packet=`build_icmp_request $src_mac $reply_ha $ip_src $ip_dst $ttl af85 8510`
+inject_pkt ext1 br0 "$packet" || exit_test
+wait_for_packet # wait for packet
+ttl=04
+real_pkt="`get_tx_pkt ext1 br0`"
+verify_pkt "$expect_pkt" "$real_pkt" || exit_test
+
+
+# send icmp from lsp-portD(on hv5) to ext1 through hv3
+dst_mac=`get_ovs_iface_mac ext1 br0`
+dst_mac=${src_mac//:} # convert xx:xx:xx:xx:xx:xx -> xxxxxxxxxxxx
+# NOTE: the hash_fn in hv5 is nw_src, NOT nw_dst
+ip_src=`ip_to_hex 10 10 2 4`
+ip_dst=`ip_to_hex 192 168 100 6`
+ttl=04
+packet=`build_icmp_request 000006080906 000006080602 $ip_src $ip_dst $ttl af76 8510`
+inject_pkt hv5 lsp-portD "$packet" || exit_test
+wait_for_packet # wait for packet
+ttl=02
+expect_pkt=`build_icmp_request f201c0a8643d $dst_mac $ip_src $ip_dst $ttl b176 8510`
+real_pkt=`get_tx_last_pkt ext1 br0`
+verify_pkt $expect_pkt $real_pkt || exit_test
+
+
+
+# try to send icmp to edge2(hv3) from hv1, but edge2(hv3) cannot receive it due
 # to incorrect hash, the packet has been forward to  edge3(hv4)
 ip_src=`ip_to_hex 10 10 2 3`
 ip_dst=`ip_to_hex 192 168 100 61`
@@ -295,14 +374,16 @@ real_pkt=`get_tx_pkt hv1 lsp-portC`
 verify_pkt $expect_pkt $real_pkt || exit_test
 
 
-pmsg "terminate hv1"
+pmsg "terminate hv1 and restart hv3"
 kill_tuplenet_daemon hv1 -TERM
-sleep 2
+kill_tuplenet_daemon hv3 -TERM
+sleep 3
+GATEWAY=1 ONDEMAND=0 tuplenet_boot hv3 192.168.100.4
 pmsg "restart hv1, consume symmetric_l3l4"
-# consume symmetric_l3l4 in selecting dst edge(hv2, hv3)
+# consume symmetric_l3l4 in selecting dst edge(hv3, hv4)
 HASH_FN=symmetric_l3l4 tuplenet_boot hv1 192.168.100.2
 wait_for_flows_unchange # waiting for install flows
-# send icmp to edge1(hv2) from hv1
+# send icmp to edge(hv3) from hv1
 ip_src=`ip_to_hex 10 10 2 3`
 ip_dst=`ip_to_hex 192 168 100 61`
 ttl=09

--- a/src/tests/tuplenet_utils.sh
+++ b/src/tests/tuplenet_utils.sh
@@ -37,6 +37,7 @@ tuplenet_boot()
     local sim_id=$1
     local ip=$2
     ovs_setenv $sim_id
+    tuplenet_setenv $sim_id
     if [ "$DISABLE_DUMMY" == 1 ]; then
         :
     else

--- a/src/tuplenet/lcp/commit_ovs.py
+++ b/src/tuplenet/lcp/commit_ovs.py
@@ -247,10 +247,6 @@ def create_tunnel(ip, uuid):
         logger.error('cannot create tunnle, cmd:%s, err:%s', cmd, err)
         return portname
 
-    # if this host is a gateway, then we should enable bfd for each tunnle port
-    if is_gateway_chassis():
-        logger.info("local host is gateway, enable bfd on %s", portname)
-        config_ovsport_bfd(portname, 'enable=true')
     return portname
 
 def create_flowbased_tunnel(chassis_id):

--- a/src/tuplenet/lcp/physical_flow.py
+++ b/src/tuplenet/lcp/physical_flow.py
@@ -3,7 +3,7 @@ import action
 import match
 from reg import *
 from logicalview import *
-from flow_common import TABLE_PIPELINE_FORWARD, TABLE_EXTRACT_METADATA
+from flow_common import TABLE_PIPELINE_FORWARD, TABLE_EXTRACT_METADATA, TABLE_DROP_PACKET
 
 pyDatalog.create_terms('Table, Priority, Match, Action')
 pyDatalog.create_terms('Action1, Action2, Action3, Action4, Action5')
@@ -81,6 +81,12 @@ def init_physical_flow_clause(options):
         action.move(NXM_Reg(REG_SRC_IDX), NXM_Reg(REG_DST_IDX), Action9) &
         (Action == Action1 + Action2 + Action3 + Action4 +
                    Action5 + Action6 + Action7 + Action8 + Action9)
+        )
+
+    output_pkt_by_reg(Priority, Match, Action) <= (
+        (Priority == 1) &
+        match.reg_outport(0xffff, Match) &
+        action.resubmit_table(TABLE_DROP_PACKET, Action)
         )
 
     output_pkt_by_reg(Priority, Match, Action) <= (

--- a/src/tuplenet/lcp/test.py
+++ b/src/tuplenet/lcp/test.py
@@ -289,8 +289,8 @@ def test_rand_entity(entity_set, rand_ls_num, rand_chassis_num, rand_lsp_num):
         logger.info('tunnel_port_oper cost time:%s, num:%d',
                     time.time()-start_time, len(tmp))
         start_time = time.time()
-        active_lsp(A,B,C,State);tmp=A.data;
-        logger.info('active_lsp cost time:%s', time.time()-start_time)
+        ecmp.ecmp_bfd_port(A,B); tmp=A.data
+        logger.info('bfd cost time:%s', time.time()-start_time)
 
         logger.info('\n\n')
 
@@ -301,9 +301,10 @@ extra['system_id'] = 'chassis-local'
 extra['options'] = {}
 extra['options']['ENABLE_REDIRECT'] = ''
 extra['options']['ENABLE_PERFORMANCE_TESTING'] = ''
-extra['options']['ONDEMAND'] = ''
-extra['options']['ENABLE_UNTUNNEL'] = ''
+extra['options']['GATEWAY'] = ''
+#extra['options']['ONDEMAND'] = ''
+#extra['options']['ENABLE_UNTUNNEL'] = ''
 extra['options']['br-int_mac'] = '00:00:00:11:11:11'
 entity_set = entity_zoo.entity_set
 lflow.init_build_flows_clause(extra['options'])
-test_rand_entity(entity_set, 20, 500, 5000)
+test_rand_entity(entity_set, 200, 500, 5000)

--- a/src/tuplenet/lcp/tuplerun.py
+++ b/src/tuplenet/lcp/tuplerun.py
@@ -52,7 +52,7 @@ def clean_env(extra, ret):
         extra['lm'].stop_all_watches()
     pipe.destory_runtime_files()
 
-def get_if_ip(ifname_list = ['eth0', 'br0']):
+def _interface_ip(ifname_list = ['eth0', 'br0']):
     for ifname in ifname_list:
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -151,7 +151,7 @@ def config_consume_ip(interface_list):
     if re.match(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", interface_list[0]):
         host_ip = interface_list[0]
     else:
-        host_ip = get_if_ip(interface_list)
+        host_ip = _interface_ip(interface_list)
     if host_ip is None:
         logger.error('cannot get a valid ip for ovs tunnel')
         killme()

--- a/src/tuplenet/lcp/tuplesync.py
+++ b/src/tuplenet/lcp/tuplesync.py
@@ -247,9 +247,8 @@ def update_ovs_side(entity_zoo):
             lflows += static_lflows
         tunnel.tunnel_port_oper(IP, UUID_CHASSIS, State)
         tunnel_port_configs = zip(IP.data, UUID_CHASSIS.data, State.data)
-        if not is_gateway_chassis():
-            ecmp.ecmp_bfd_port(PORT_NAME, State)
-            bfd_port_configs = zip(PORT_NAME.data, State.data)
+        ecmp.ecmp_bfd_port(PORT_NAME, State)
+        bfd_port_configs = zip(PORT_NAME.data, State.data)
 
         cost_time = time.time() - start_time
         entity_zoo.sweep_zoo()
@@ -258,7 +257,7 @@ def update_ovs_side(entity_zoo):
     # on testing mode, it avoids similar flow replacing the others
     if os.environ.has_key('RUNTEST'):
         ovs_flows_add.sort()
-    logger.info("pydatalog cost %fs in generating flows", cost_time)
+    logger.info("pydatalog cost %fs in computing flows and config", cost_time)
     if not had_clean_ovs_flows:
         had_clean_ovs_flows = True
         ovs_flows_add += _get_ovs_arp_ip_mac_from_file()

--- a/src/tuplenet/tools/edge-operate.py
+++ b/src/tuplenet/tools/edge-operate.py
@@ -458,7 +458,7 @@ def _init_ecmp_road(central_lr, vip, vip_prefix, virt_ip, virt_prefix,
 
     # create lsr command
     outport = "{}_to_{}".format(edge_lr_name, out_ls_name)
-    tp_cmd_list.append(_cmd_new_lsr(edge_lr_name, vip, vip_prefix,
+    tp_cmd_list.append(_cmd_new_lsr(edge_lr_name, '0.0.0.0', 0,
                                     ext_gw, outport))
 
     outport = "{}_to_{}".format(edge_lr_name, inner_ls_name)

--- a/src/tuplenet/version.py
+++ b/src/tuplenet/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 git_version = ''


### PR DESCRIPTION
1. Deleting a edge chassis in etcd means we should stop this chassis in a while,
but this chassis should work as usual to handle traffic. Once we found there is
no traffic go through this edge, then we can stop tuplenet safely without lossing
any packets

2. add testcase in test_simple_bfd.sh test_simple_ecmp3.sh
3. update ecmp.py to add clause which help to disable bfd for all tunnel ports
4. update lrp_ingress.py to stop sending icmp feedback if we delete a edge chassis
5. update edge-operate.py to fix lsr config bug
6. bump version to 0.2.2