### PR TITLE
Do not re-register chassis while starting tuplenet

### DIFF
--- a/src/tests/etcd_utils.sh
+++ b/src/tests/etcd_utils.sh
@@ -144,6 +144,13 @@ etcddel()
     etcdctl --endpoints $etcd_client_specs del ${prefix}$1 || return 1
 }
 
+etcdget()
+{
+    local prefix=${tuplenet_prefix}entity_view/
+    pmsg "etcdget key:${prefix}${1}"
+    echo "`etcdctl --endpoints $etcd_client_specs get ${prefix}$1`"
+}
+
 etcd_chassis_add()
 {
     hv=$1
@@ -151,6 +158,14 @@ etcd_chassis_add()
     tick=$3
     etcdput chassis/$hv ip=$ip,tick=$tick
 }
+
+etcd_get_chassis_tick()
+{
+    hv=$1
+    info=`etcdget chassis/$hv`
+    echo `echo "$info" | awk -F'=' '{print $3}'`
+}
+
 
 etcd_chassis_del()
 {

--- a/src/tests/test_simple_hv.sh
+++ b/src/tests/test_simple_hv.sh
@@ -35,6 +35,18 @@ etcd_ls_link_lr LS-B LR-A 10.10.2.1 24 00:00:06:08:06:02
 etcd_lsp_add LS-A lsp-portA 10.10.1.2 00:00:06:08:06:03
 etcd_lsp_add LS-B lsp-portB 10.10.2.3 00:00:06:08:06:04
 etcd_lsp_add LS-B lsp-portC 10.10.2.4 00:00:06:08:06:05
+wait_for_flows_unchange
+
+# reboot tuplenet would not update chassis tick.
+prev_tick="`etcd_get_chassis_tick hv1`"
+kill_tuplenet_daemon hv1 -TERM
+sleep 2
+tuplenet_boot hv1 192.168.100.1
+tick="`etcd_get_chassis_tick hv1`"
+if [ $tick != $prev_tick ]; then
+    echo "hv1 prev tick:$prev_tick, current tick:$tick"
+    exit_test
+fi
 
 wait_for_flows_unchange
 

--- a/src/tests/tuplenet_utils.sh
+++ b/src/tests/tuplenet_utils.sh
@@ -156,6 +156,7 @@ remove_ecmp_road()
     vip=$2
     # NOTE: only one etcd address
     ovs_setenv $sim_id
+    tuplenet_setenv $sim_id
     echo "yes" |  PATH=$PATH:$CONTROL_BIN_PATH/bin/  $PYTHON ../tuplenet/tools/edge-operate.py --endpoint $etcd_client_specs \
                        --prefix $tuplenet_prefix --op=remove \
                        --phy_br=br0 --vip=$vip || return 1

--- a/src/tuplenet/lcp/commit_ovs.py
+++ b/src/tuplenet/lcp/commit_ovs.py
@@ -21,7 +21,7 @@ class OVSToolErr(Exception):
     pass
 
 def call_popen(cmd, commu=None, shell=False):
-    child = subprocess.Popen(cmd, shell, stdout=subprocess.PIPE,
+    child = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE,
                              stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     if commu is None:
         output = child.communicate()
@@ -192,7 +192,7 @@ def system_id():
              "table":"Open_vSwitch","columns":["external_ids"], \
              "where":[]}]']
     try:
-        json_str = call_popen(cmd, shell=True)
+        json_str = call_popen(cmd, shell=False)
     except Exception:
         logger.error('failed to get system-id')
         return

--- a/src/tuplenet/lcp/ecmp.py
+++ b/src/tuplenet/lcp/ecmp.py
@@ -84,6 +84,7 @@ def init_ecmp_clause(options):
         (Y == OFPORT)
         )
 
+    # adding and readding may generate same flow, it is ok.
     ecmp_static_route(LR, Priority, Match, Action, State) <= (
         lr_array(LR, UUID_LR, State1) &
         (ecmp_aggregate_outport[X] == Y) &

--- a/src/tuplenet/lcp/middle_table.py
+++ b/src/tuplenet/lcp/middle_table.py
@@ -61,6 +61,7 @@ pyDatalog.create_terms('A, B, C, X, Y, Z, UUID_CHASSIS')
 (gateway_ofport[X] == Y) <= (_gateway_ofport[X] == Y)
 (gateway_ofport[X] == Y) <= (_gateway_ofport_readd[X] == Y)
 
+# it may output same flows, because we have adding and readding
 redirect_other_chassis(Priority, Match, Action, State) <= (
     (Priority == 1) &
     (gateway_ofport[X] == OFPORT) &

--- a/src/tuplenet/tools/edge-operate.py
+++ b/src/tuplenet/tools/edge-operate.py
@@ -82,7 +82,7 @@ def tpctl_execute(cmd_list):
         cmd = cmd.split()
         cmd.insert(1, prefix_cmd)
         cmd.insert(1, endpoint_cmd)
-        cm.call_popen(cmd, commu='yes\n', shell=True)
+        cm.call_popen(cmd, commu='yes\n', shell=False)
 
 
 class TPObject:


### PR DESCRIPTION
1. re-register chassis cause other tuplenet trigger flow change.
   Update tuplesync.py to check if it need to register itself to etcd
2. update testcases
3. update edge-operate.py