### PR TITLE
Make tpctl support deleting chasiss by ip[vip:TupleNet-vip#4]

### DIFF
--- a/src/tests/test_simple_tpctl.sh
+++ b/src/tests/test_simple_tpctl.sh
@@ -319,6 +319,27 @@ CH-A:
 equal_str "$result" "$expected" || exit_test
 (tpctl ch del CH-A | grep 'CH-A deleted') || exit_test
 
+etcdctl --endpoints ${etcd_client_specs} put ${DATA_STORE_PREFIX}/entity_view/chassis/CH-B 'ip=10.199.211.132,tick=1524118021' || exit_test
+(tpctl ch del "10.199.211.132" | grep 'CH-B deleted') || exit_test
+
+etcdctl --endpoints ${etcd_client_specs} put ${DATA_STORE_PREFIX}/entity_view/chassis/CH-A 'ip=10.199.211.133,tick=1524118021' || exit_test
+etcdctl --endpoints ${etcd_client_specs} put ${DATA_STORE_PREFIX}/entity_view/chassis/CH-B 'ip=10.199.211.133,tick=1524118021' || exit_test
+etcdctl --endpoints ${etcd_client_specs} put ${DATA_STORE_PREFIX}/entity_view/chassis/CH-C 'ip=10.199.211.134,tick=1524118021' || exit_test
+etcdctl --endpoints ${etcd_client_specs} put ${DATA_STORE_PREFIX}/entity_view/chassis/CH-D 'ip=10.199.211.134,tick=1524118021' || exit_test
+result="`tpctl ch del "10.199.211.133"`"
+(echo "$result" | grep 'CH-A deleted') || exit_test
+(echo "$result" | grep 'CH-B deleted') || exit_test
+! (echo "$result" | grep 'CH-C deleted') || exit_test
+! (echo "$result" | grep 'CH-D deleted') || exit_test
+
+result="`tpctl ch del "10.199.211.134"`"
+(echo "$result" | grep 'CH-C deleted') || exit_test
+(echo "$result" | grep 'CH-D deleted') || exit_test
+
+(tpctl ch del "12.12.11.12" | grep 'failed to get chassis by ip') || exit_test
+(tpctl ch del "CH-K" | grep 'unable to get chassis') || exit_test
+
+
 # inject conflicted data and test
 tpctl ls add LS-A || exit_test
 tpctl lsp add LS-A LSP-A-1 192.168.0.1 || exit_test


### PR DESCRIPTION
1. currently the tpctl del chassis by chassis-id, but ip is another
key for chassis list.
2. make tpctl support deleting chassis by ip.
tpctl found the chassis-id is an ip, it search the whole chassis
list to delete chassis which has this ip.
e.g.

[root@docker-ovs01 control]# ./bin/tpctl ch show
7153b1c2-11f2-442a-ad16-0099518f47e2:
  - ip  : 111.111.114.30
  - tick: 1553169673

hv2:
  - ip  : 111.111.114.39
  - tick: 1551835312

hv77:
  - ip  : 111.111.114.30
  - tick: 1552300784

hv_edge1:
  - ip  : 111.111.114.38
  - tick: 1551873308

hv_edge2:
  - ip  : 111.111.114.40
  - tick: 155187336

[root@docker-ovs01 control]# ./bin/tpctl ch del 111.111.114.30
hv77 deleted
7153b1c2-11f2-442a-ad16-0099518f47e2 deleted