### PR TITLE
convert tentacle's pipe to socket [vip:TupleNet-vip#6]

### DIFF
--- a/src/tuplenet/lcp/tentacle.py
+++ b/src/tuplenet/lcp/tentacle.py
@@ -2,47 +2,43 @@ import time
 import threading
 import logging
 import pyDatalog
+import pickle
 from tp_utils import pipe
 logger = logging.getLogger(__name__)
 
+def data_handler(entity_zoo, data):
+    if len(data) == 0:
+        return
+    opcode, msg = pickle.loads(data)
+    if opcode == 'query_clause':
+        with entity_zoo.lock:
+            try:
+                answer = pyDatalog.pyDatalog.ask(msg)
+                if answer is None:
+                    logger.info('clause %s has no result', msg)
+                    return
+
+                output = ""
+                for line in answer.answers:
+                    output += str(line) + '\n'
+                return output
+            except Exception as err:
+                logger.info('failed to query_clause, the clause is %s', msg)
+    elif opcode == 'query_entity':
+        with entity_zoo.lock:
+            try:
+                logical_entity = entity_zoo.entity_set[msg]
+            except Exception as err:
+                logger.info('failed to query_entity, the query entity is %s', msg)
+                return
+            return str(logical_entity)
+    else:
+        logger.info('unsupport command type:%s', opcode)
+
 def monitor_debug_info(entity_zoo, extra):
     pyDatalog.Logic(extra['logic'])
-    while True:
-        try:
-            data = pipe.read_debug_pipe()
-        except Exception as err:
-            logger.warning('failed to monitor income msg from %s', DEBUG_PIPE_PATH)
-            time.sleep(0.1)
-            continue
-        opcode, msg = data
-        if opcode == 'query_clause':
-            with entity_zoo.lock:
-                try:
-                    answer = pyDatalog.pyDatalog.ask(msg)
-                    if answer is None:
-                        logger.info('clause %s has no result', msg)
-                        continue
-
-                    output = ""
-                    for line in answer.answers:
-                        output += str(line) + '\n'
-                    logger.info('--------- clause %s result ----------', msg)
-                    logger.info('\n%s', output)
-                    logger.info('--------- clause %s end ----------', msg)
-                except Exception as err:
-                    logger.info('failed to query_clause, the clause is %s', msg)
-        elif opcode == 'query_entity':
-            with entity_zoo.lock:
-                try:
-                    logical_entity = entity_zoo.entity_set[msg]
-                except Exception as err:
-                    logger.info('failed to query_entity, the query entity is %s', msg)
-                    continue
-                logger.info('--------- entity %s result ----------', msg)
-                logger.info('\n%s', logical_entity)
-                logger.info('--------- entity %s end ----------', msg)
-        else:
-            logger.info('unsupport command type:%s', opcode)
+    read_fn = pipe.create_debug_pipe(pipe.DEBUG_PIPE_PATH, data_handler)
+    read_fn(entity_zoo)
 
 def start_monitor_debug_info(entity_zoo, extra):
     t = threading.Thread(target = monitor_debug_info, args = (entity_zoo, extra))

--- a/src/tuplenet/tools/dump-tuplenet.py
+++ b/src/tuplenet/tools/dump-tuplenet.py
@@ -2,14 +2,24 @@
 import sys
 import os
 import pickle
+import socket
 from optparse import OptionParser
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(parent_dir)
 from tp_utils import pipe
 
+MAX_RECV_BUF = 102400
+
 def write_debug_pipe(obj):
-    with open(pipe.DEBUG_PIPE_PATH, 'wb') as fd:
-        pickle.dump(obj, fd)
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(pipe.DEBUG_PIPE_PATH)
+        data = pickle.dumps(obj)
+        sock.sendall(data)
+        data = sock.recv(MAX_RECV_BUF)
+        print(data)
+    except Exception as err:
+        print("failed to get result from DEBUG socket, err:%s" % err)
 
 if __name__ == "__main__":
     usage = """usage: python %prog [options]


### PR DESCRIPTION
1. tentacle should send result back to dump-tuplenet.py, so socket
is a good candidate to replace pipe